### PR TITLE
Add improved SEO metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.3.0] - 2025-06-12
+- Weitere SEO-Metriken wie Sprache, Zeichensatz und Text-zu-HTML-Verhältnis
+- Prüfung der Überschriftenhierarchie
+- Quote von Bildern mit Alt-Text
+
+## [1.2.0] - 2025-06-12
+- Zusätzliche SEO-Metriken (Meta-Keywords, OG-Bild, Viewport)
+- Geschätzte Lesezeit
+- JSON-Ausgabe über `--json`
+
+## [1.1.0] - 2025-06-12
+- Erweiterte SEO-Analyse mit Robots- und Open-Graph-Tags
+- Ausgabe von Lesbarkeitsmetriken
+- Warnung bei mehrfachen `h1`-Überschriften
+
 ## [1.0.0] - 2025-06-11
 - Erste Veröffentlichung des SEO-Werkzeugs
 - Deutsche Lokalisierung des Programms und der Dokumentation

--- a/README.md
+++ b/README.md
@@ -34,14 +34,31 @@ Starte das Werkzeug mit einer zu analysierenden URL:
 python seo_tool.py https://example.com
 ```
 
+Mit `--json` erhältst du die Ausgabe im JSON-Format:
+
+```bash
+python seo_tool.py https://example.com --json
+```
+
 Das Werkzeug gibt folgende Metriken aus:
 
 - Seitentitel und Meta-Description
 - Anzahl der Wörter
 - Überschriftenanzahl (`h1`-`h6`)
 - Anzahl der Bilder sowie wie viele Bilder kein `alt`-Attribut besitzen
+- Quote der Bilder mit `alt`-Text
 - Vorhandene Canonical-URL
 - Anzahl interner und externer Links
+- Vorhandenes Robots-Meta-Tag
+- Meta-Keywords
+- Open-Graph-Titel, -Beschreibung und -Bild
+- Sprache (`lang`-Attribut) und Zeichensatz der Seite
+- Flesch-Lesbarkeitsindex und Flesch-Kincaid-Stufe
+- Geschätzte Lesezeit
+- Verhältnis von Text zu HTML
+- Warnungen zur Überschriftenstruktur
+- Vorhandenes Viewport-Meta-Tag
+- Warnung bei mehreren `h1`-Überschriften
 
 ## Tests ausführen
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "seo-tool"
-version = "1.0.0"
+version = "1.3.0"
 description = "Ein einfaches Kommandozeilenwerkzeug zur Analyse grundlegender SEO-Metriken"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,6 +13,7 @@ authors = [{name = "Noelmarketing", email = "noela808@googlemail.com"}]
 dependencies = [
     "requests",
     "beautifulsoup4",
+    "textstat",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+textstat

--- a/seo_tool.py
+++ b/seo_tool.py
@@ -1,10 +1,13 @@
 import argparse
+import json
+import re
 from urllib.parse import urlparse
 
-__version__ = "1.0.0"
+__version__ = "1.3.0"
 
 import requests
 from bs4 import BeautifulSoup
+from textstat import flesch_reading_ease, flesch_kincaid_grade
 
 
 def fetch_html(url: str) -> str:
@@ -23,6 +26,21 @@ def parse_seo_metrics(html: str, base_url: str | None = None) -> dict:
     """
     soup = BeautifulSoup(html, "html.parser")
 
+    html_lang = ""
+    if soup.html and soup.html.get("lang"):
+        html_lang = soup.html["lang"].strip()
+
+    charset = ""
+    charset_tag = soup.find("meta", charset=True)
+    if charset_tag:
+        charset = charset_tag.get("charset", "").lower().strip()
+    else:
+        ct_tag = soup.find("meta", attrs={"http-equiv": "Content-Type"})
+        if ct_tag and ct_tag.get("content"):
+            m = re.search(r"charset=([\w-]+)", ct_tag["content"], re.I)
+            if m:
+                charset = m.group(1).lower()
+
     title = soup.title.string.strip() if soup.title and soup.title.string else ""
     meta_description = ""
     meta_tag = soup.find("meta", attrs={"name": "description"})
@@ -30,14 +48,58 @@ def parse_seo_metrics(html: str, base_url: str | None = None) -> dict:
         meta_description = meta_tag["content"].strip()
 
     headings = {f"h{i}": len(soup.find_all(f"h{i}")) for i in range(1, 7)}
+    multiple_h1 = headings.get("h1", 0) > 1
+
+    heading_issues: list[str] = []
+    all_headings = soup.find_all(re.compile(r"^h[1-6]$"))
+    last_level = 0
+    seen_h1 = False
+    for tag in all_headings:
+        level = int(tag.name[1])
+        if not seen_h1 and level != 1:
+            heading_issues.append("Erste Überschrift ist nicht h1")
+        if last_level and level > last_level + 1:
+            heading_issues.append(f"Sprung von h{last_level} zu h{level}")
+        if level == 1:
+            seen_h1 = True
+        last_level = level
+    if not seen_h1:
+        heading_issues.append("Keine h1-Überschrift gefunden")
     images = soup.find_all("img")
     images_with_alt = sum(1 for img in images if img.get("alt"))
     images_without_alt = len(images) - images_with_alt
+
+    robots = ""
+    robots_tag = soup.find("meta", attrs={"name": "robots"})
+    if robots_tag and robots_tag.get("content"):
+        robots = robots_tag["content"].strip()
+
+    keywords = ""
+    keywords_tag = soup.find("meta", attrs={"name": "keywords"})
+    if keywords_tag and keywords_tag.get("content"):
+        keywords = keywords_tag["content"].strip()
+
+    og_title = ""
+    og_title_tag = soup.find("meta", property="og:title")
+    if og_title_tag and og_title_tag.get("content"):
+        og_title = og_title_tag["content"].strip()
+
+    og_description = ""
+    og_desc_tag = soup.find("meta", property="og:description")
+    if og_desc_tag and og_desc_tag.get("content"):
+        og_description = og_desc_tag["content"].strip()
+
+    og_image = ""
+    og_img_tag = soup.find("meta", property="og:image")
+    if og_img_tag and og_img_tag.get("content"):
+        og_image = og_img_tag["content"].strip()
 
     canonical_url = ""
     canonical_tag = soup.find("link", rel="canonical")
     if canonical_tag and canonical_tag.get("href"):
         canonical_url = canonical_tag["href"].strip()
+
+    has_viewport = bool(soup.find("meta", attrs={"name": "viewport"}))
 
     internal_links = external_links = 0
     links = soup.find_all("a", href=True)
@@ -58,6 +120,11 @@ def parse_seo_metrics(html: str, base_url: str | None = None) -> dict:
 
     text = soup.get_text(separator=" ")
     words = [w for w in text.split() if w]
+    reading_ease = flesch_reading_ease(text)
+    reading_grade = flesch_kincaid_grade(text)
+    reading_time = len(words) / 200
+    text_to_html_ratio = len(text) / len(html) if html else 0
+    alt_text_ratio = images_with_alt / len(images) if images else 0
 
     return {
         "title": title,
@@ -67,9 +134,24 @@ def parse_seo_metrics(html: str, base_url: str | None = None) -> dict:
         "image_count": len(images),
         "images_with_alt": images_with_alt,
         "images_without_alt": images_without_alt,
+        "alt_text_ratio": alt_text_ratio,
+        "html_lang": html_lang,
+        "charset": charset,
+        "heading_issues": heading_issues,
+        "text_to_html_ratio": text_to_html_ratio,
         "canonical_url": canonical_url,
+        "meta_robots": robots,
+        "meta_keywords": keywords,
+        "og_title": og_title,
+        "og_description": og_description,
+        "og_image": og_image,
         "internal_links": internal_links,
         "external_links": external_links,
+        "reading_ease": reading_ease,
+        "reading_grade": reading_grade,
+        "reading_time": reading_time,
+        "has_viewport": has_viewport,
+        "multiple_h1": multiple_h1,
     }
 
 
@@ -77,10 +159,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Einfacher SEO-Analysator")
     parser.add_argument("url", help="URL, die analysiert werden soll")
     parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("--json", action="store_true", help="Ausgabe als JSON")
     args = parser.parse_args()
 
     html = fetch_html(args.url)
     metrics = parse_seo_metrics(html, base_url=args.url)
+
+    if args.json:
+        print(json.dumps(metrics, ensure_ascii=False, indent=2))
+        return
 
     print(f"Titel: {metrics['title']}")
     print(f"Meta-Description: {metrics['meta_description']}")
@@ -92,10 +179,35 @@ def main() -> None:
     print(f"Bilder: {metrics['image_count']}")
     print(f"Bilder mit Alt-Text: {metrics['images_with_alt']}")
     print(f"Bilder ohne Alt-Text: {metrics['images_without_alt']}")
+    print(f"Alt-Text-Quote: {metrics['alt_text_ratio']:.2f}")
+    if metrics['html_lang']:
+        print(f"Sprache der Seite: {metrics['html_lang']}")
+    if metrics['charset']:
+        print(f"Zeichenkodierung: {metrics['charset']}")
+    if metrics['heading_issues']:
+        for issue in metrics['heading_issues']:
+            print(f"Warnung: {issue}")
+    print(f"Text-zu-HTML-Verhältnis: {metrics['text_to_html_ratio']:.2f}")
     if metrics['canonical_url']:
         print(f"Canonische URL: {metrics['canonical_url']}")
+    if metrics['meta_robots']:
+        print(f"Meta-Robots: {metrics['meta_robots']}")
+    if metrics['meta_keywords']:
+        print(f"Meta-Keywords: {metrics['meta_keywords']}")
+    if metrics['og_title']:
+        print(f"OG Title: {metrics['og_title']}")
+    if metrics['og_description']:
+        print(f"OG Description: {metrics['og_description']}")
+    if metrics['og_image']:
+        print(f"OG Image: {metrics['og_image']}")
     print(f"Interne Links: {metrics['internal_links']}")
     print(f"Externe Links: {metrics['external_links']}")
+    print(f"Lesbarkeitsindex: {metrics['reading_ease']:.2f}")
+    print(f"Lesestufe (Flesch-Kincaid): {metrics['reading_grade']:.2f}")
+    print(f"Geschätzte Lesezeit: {metrics['reading_time']:.2f} Minuten")
+    print(f"Viewport-Tag vorhanden: {metrics['has_viewport']}")
+    if metrics['multiple_h1']:
+        print("Warnung: Mehrere H1-Überschriften gefunden")
 
 
 if __name__ == "__main__":

--- a/tests/test_seo_tool.py
+++ b/tests/test_seo_tool.py
@@ -3,10 +3,17 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 import seo_tool
 
 HTML = """
-<html>
+<html lang="en">
 <head>
 <title>Test Page</title>
+<meta charset="utf-8" />
 <meta name="description" content="This is a test page for SEO metrics" />
+<meta name="robots" content="index, follow" />
+<meta name="keywords" content="test, seo" />
+<meta property="og:title" content="OG Test Title" />
+<meta property="og:description" content="OG Description" />
+<meta property="og:image" content="/og.jpg" />
+<meta name="viewport" content="width=device-width" />
 <link rel="canonical" href="https://example.com/test" />
 </head>
 <body>
@@ -33,5 +40,20 @@ def test_parse_seo_metrics():
     assert metrics["image_count"] == 2
     assert metrics["images_with_alt"] == 1
     assert metrics["images_without_alt"] == 1
+    assert metrics["alt_text_ratio"] == 0.5
     assert metrics["internal_links"] == 1
     assert metrics["external_links"] == 1
+    assert metrics["meta_robots"] == "index, follow"
+    assert metrics["meta_keywords"] == "test, seo"
+    assert metrics["og_title"] == "OG Test Title"
+    assert metrics["og_description"] == "OG Description"
+    assert metrics["og_image"] == "/og.jpg"
+    assert metrics["has_viewport"] is True
+    assert metrics["multiple_h1"] is False
+    assert isinstance(metrics["reading_ease"], float)
+    assert isinstance(metrics["reading_grade"], float)
+    assert isinstance(metrics["reading_time"], float)
+    assert metrics["html_lang"] == "en"
+    assert metrics["charset"] == "utf-8"
+    assert metrics["heading_issues"] == []
+    assert isinstance(metrics["text_to_html_ratio"], float)


### PR DESCRIPTION
## Summary
- add detection of html language, charset, and heading hierarchy issues
- compute alt text ratio and text-to-HTML ratio
- print new metrics in CLI output
- document expanded metrics in the README and changelog
- bump version to 1.3.0 and update tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a8072ae00832c95a71c10351d6fe2